### PR TITLE
Fix settings page link in header

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -45,7 +45,7 @@ export const Header = async () => {
               掲示板
             </Button>
             <Button variant="link" className="text-lg" asChild>
-              <Link href="/settings">
+              <Link href="/setting">
                 <Settings className="mt-1" />
                 マイページ
               </Link>


### PR DESCRIPTION
Updated the header navigation link from '/settings' to '/setting' to ensure correct routing to the user settings page.